### PR TITLE
Update debugnyan@2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest --env=node"
   },
   "dependencies": {
-    "debugnyan": "^2.0.1",
+    "debugnyan": "^2.0.2",
     "lodash": "^4.17.4",
     "standard-http-error": "^2.0.0",
     "validator.js": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,9 +600,9 @@ debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debugnyan@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/debugnyan/-/debugnyan-2.0.1.tgz#d3a5a66ac311b76e881405c78cefe57c78859a5f"
+debugnyan@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/debugnyan/-/debugnyan-2.0.2.tgz#83138804167ab2733988b9b0b90f0d11c9d1e1a1"
   dependencies:
     bunyan "^1.8.1"
     debug "^2.2.0"


### PR DESCRIPTION
This also updates the resolved `dtrace-provider` to `0.8.7`, which includes the compatibility fix for node 10.