### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-  - 7.10
+  - 8


### PR DESCRIPTION
We were setting travis to node version 7.10, which seems to no longer be supported. Switching to version 8 fixes the build.