### PR TITLE
Update tweetnacl@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eslint": "^4.6.1",
     "lodash": "^4.17.4",
     "standard-http-error": "^2.0.0",
+    "tweetnacl": "^1.0.0",
     "validator.js": "^2.0.3",
     "validator.js-asserts": "^3.1.0"
   },

--- a/src/sign.js
+++ b/src/sign.js
@@ -36,8 +36,8 @@ module.exports = function sign({ headers: requestHeaders, keyId, secretKey } = {
 
   // Generate signature using the ed25519 algorithm.
   const signature = Buffer.from(nacl.sign.detached(
-    Buffer.from(message),
-    Buffer.from(secretKey, 'hex')
+    Uint8Array.from(Buffer.from(message)),
+    Uint8Array.from(Buffer.from(secretKey, 'hex'))
   )).toString('base64');
 
   // Return a signature in the format described by `draft-cavage-http-signatures-07` internet draft.

--- a/src/verify.js
+++ b/src/verify.js
@@ -49,9 +49,9 @@ module.exports = function verify({ headers: requestHeaders, publicKey } = {}, { 
 
   // Verify the signature using the ed25519 algorithm.
   const verified = nacl.sign.detached.verify(
-    Buffer.from(message),
-    Buffer.from(signature, 'base64'),
-    Buffer.from(publicKey, 'hex')
+    Uint8Array.from(Buffer.from(message)),
+    Uint8Array.from(Buffer.from(signature, 'base64')),
+    Uint8Array.from(Buffer.from(publicKey, 'hex'))
   );
 
   if (!verified) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,6 +2689,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
+tweetnacl@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.0.tgz#713d8b818da42068740bf68386d0479e66fc8a7b"
+  integrity sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"


### PR DESCRIPTION
Fixes BC introduced by tweetnacl@1.0.0 where all arguments must be UInt8Array instances.

Closes #8.